### PR TITLE
Fix for LoanContract: payback() caller should be borrower

### DIFF
--- a/frontends/benchmarks/smartcontracts/valid/LoanContract/LoanContract.scala
+++ b/frontends/benchmarks/smartcontracts/valid/LoanContract/LoanContract.scala
@@ -120,7 +120,7 @@ trait LoanContract extends Contract {
   final def payback(): Unit = {
     dynRequire(addr.balance >= Msg.value)
     dynRequire(Msg.value >= premiumAmount + wantedAmount)
-    dynRequire(Msg.sender == lender)
+    dynRequire(Msg.sender == borrower)
 
     if (currentState == WaitingForPayback) {
       assert(stateInvariant(currentState, visitedStates))


### PR DESCRIPTION
This is the fix on the Loan Contract that was discussed via email back in March (2019-03-26):

----
Hello Jad,

A quick question regarding a small issue I ran into with the
LoanContract in Stainless/Smart, trying to debug its execution in the
Byzcoin-Ethereum integration. The symptom is that, as the test is
written, the lend() method works fine, but the payback() method always
fails.

Examining the Solidity code, and tracing it back to the Scala code as
well as the report written by Romain Jufer, I believe there is a small
mistake in the preconditions.

In GitHub [1], as well as in the report (p.10, lines 48-62), the
payback() method requires that the message sender is the lender.
My understanding is, however, that it should be the borrower to call
payback() (as also described in the paper p.9 point 4.).

Is my understanding correct?

Thank you and best regards,

-Christian

[1] https://github.com/epfl-lara/smart/blob/master/frontends/benchmarks/smartcontracts/valid/LoanContract/LoanContract.scala

----